### PR TITLE
fix(react): Add support for React v16

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, cloneElement, Children } from 'react';
+import { Component, cloneElement, Children } from 'react';
+import PropTypes from 'prop-types';
 import scrollMonitor from './scrollMonitor';
 
 export default class ScrollMonitor extends Component {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "./build/scrollMonitor.js": "./build/scrollMonitorClient.js"
   },
   "peerDependency": {
-    "react": ">=0.13"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "scrollmonitor": "1.0.12"
   },
   "devDependencies": {


### PR DESCRIPTION
React v15 deprecated React.PropTypes in favor of the 'prop-types' package, but React v16 removed it entirely. To ensure consumer have a clear upgrade path: all references of `React.PropTypes` have been replaced with `PropTypes` from `'prop-types'`.