### PR TITLE
feat(scrollmonitor): Upgrade scrollMonitor, support any 1.x version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "scrollmonitor": "1.0.12"
+    "scrollmonitor": "^1.2.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^4.0.0",


### PR DESCRIPTION
Noticed that our version of scrollMonitor had lagged behind a bit, and was locked to an exact version. This brings us up to date, and also loosens the version range to support the latest major version.